### PR TITLE
fix markdown for link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ As with other labs, we have provided a set of tests all of which must be passing
 
 ## Resources
 
-- Richard Feldman, ["React 0.14: Why Local Component State is a Trap" (https://www.safaribooksonline.com/blog/2015/10/29/react-local-component-state/)
+- Richard Feldman, ["React 0.14: Why Local Component State is a Trap"](https://www.safaribooksonline.com/blog/2015/10/29/react-local-component-state/)
 - Code Refatoring (Wikipedia): https://en.wikipedia.org/wiki/Code_refactoring


### PR DESCRIPTION
Typo missing ending brackets for MD link.